### PR TITLE
Make Micro-Dawn show up with ReStock installed

### DIFF
--- a/GameData/UniversalStorage2/Patches/MicroDawn.cfg
+++ b/GameData/UniversalStorage2/Patches/MicroDawn.cfg
@@ -1,4 +1,60 @@
-+PART[ionEngine]
++PART[ionEngine]:Needs[ReStock]:After[ReStock]
+{
+    @name = miniIonEngine
+
+   // @scale = 0.5
+    @rescaleFactor  = 0.25
+
+    @title = IX-631 Micro "Dawn" Electric Propulsion System
+    @description = A tiny version of the Dawn engine, used for tiny probes
+
+    @MODULE[ModuleEnginesFX]
+    {
+        // Doubles the thrust of the copied engine.
+        @maxThrust /= 8
+        @PROPELLANT[ElectricCharge]
+        {
+            @ratio /= 32
+        }
+        @PROPELLANT[XenonGas]
+        {
+            @ratio /= 8
+        }
+    }
+    -EFFECTS {}
+    EFFECTS
+	{		
+		IonPlume
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_IonEngine
+				volume = 0.0 0.0
+				volume = 0.05 0.20
+				volume = 1.0 0.25
+				pitch = 0.0 0.2
+				pitch = 1.0 0.8
+				loop = true
+			}
+			MODEL_MULTI_PARTICLE
+			{
+				modelName = Squad/FX/IonPlume
+				transformName = thrustTransform
+				emission = 0.0 0.0
+				emission = 0.25 0.5			
+				//emission = 1.0 1.0
+				//speed = 0.0 0.0
+				//speed = 1.0 1.0
+				localPosition = 0, 0, 0.03
+			}
+		}
+	}
+
+
+}
+
++PART[ionEngine]:Needs[!ReStock]
 {
     @name = miniIonEngine
 


### PR DESCRIPTION
The solutions is to load the patch after ReStock. Code duplication is due to my understanding of how MM works, and my inability to express "if ReStock is installed, load this after ReStock" in MM syntax.