### PR TITLE
fix "Brimary" -> "Primary"

### DIFF
--- a/GameData/UniversalStorage2/Localization/en-us.cfg
+++ b/GameData/UniversalStorage2/Localization/en-us.cfg
@@ -44,7 +44,7 @@ Localization
 		#autoLOC_US_QuadHeight = Quad	
 		
 		#autoLOC_US_DeployPrimaryBays = Deploy Primary Bays
-		#autoLOC_US_RetractPrimaryBays = Retract Brimary Bays
+		#autoLOC_US_RetractPrimaryBays = Retract Primary Bays
 		#autoLOC_US_TogglePrimaryBays = Toggle Primary Bays
 		#autoLOC_US_LockPrimaryBays = Lock Primary Bays
 		#autoLOC_US_UnlockPrimaryBays = Unlock Primary Bays


### PR DESCRIPTION
Simple typo fix; `Brimary` -> `Primary`