### PR TITLE
Fix attN = Null for NodeSwitchable parts

### DIFF
--- a/USSourceDev/UniversalStorage/SwitchModules/USNodeSwitch.cs
+++ b/USSourceDev/UniversalStorage/SwitchModules/USNodeSwitch.cs
@@ -140,9 +140,11 @@ namespace UniversalStorage2
 
             ModulePartVariants.UpdatePartPosition(previousNode, newNode);
 
-            newNode.attachedPart = previousNode.attachedPart;
+            var prevAttatchedPart = previousNode.attachedPart;
 
             previousNode.attachedPart = null;
+
+            newNode.attachedPart = prevAttatchedPart;
         }
     }
 }


### PR DESCRIPTION
# The issue

## Reports

As reported several times e.g. [from 2018](https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii-131-and-145-170/&do=findComment&comment=3491600) and [recent](https://forum.kerbalspaceprogram.com/index.php?/topic/177385-universal-storage-ii-131-and-145-170/&do=findComment&comment=4097752), parts with USNodeSwitch will have their lower stack node attN = Null after updates, which breaks Connected Living Space compatibility.

## Reproduction

The reproduction is rather simple following steps:
1. Place a service core in the editor
2. Stack anything below the core
3. Save & load the vessel
4. Save the vessel again

## Outcome

The attN value of the Stack Node on the service core becomes Null, seen in the saved craft file.

# Example

CLS is used for better depiction of the issue:
![pic1](https://user-images.githubusercontent.com/55565923/206829670-2b8905df-b773-42e4-a8cc-89ffd6f7b0af.png)
A simple research module in the VAB, utilizing a mk1-3 pod and a lab, with an octo core in between.
As shown in the CLS window and part highlights, these are considered connected and form a single living space.
Now save the vessel. In the craft file, the attN values of the octo core are expected:
```
link = Large.Crewed.Lab_4294161264
attN = StackNodeUpper,mk1-3pod_4294227050_0|0.596700013|0_0|1|0_0|0.596700013|0_0|1|0
attN = StackNodeTwo,Large.Crewed.Lab_4294161264_0|0.198883504|0_0|-1|0_0|0.198883504|0_0|-1|0
```

![pic2](https://user-images.githubusercontent.com/55565923/206829844-6e52b59d-bc37-4023-8844-273ef1b30916.png)
Now load the vessel, and save it again.
In the craft file, the attN value for the lower Stack Node has changed to Null:
```
link = Large.Crewed.Lab_4294161264
attN = StackNodeUpper,mk1-3pod_4294227050_0|0.596700013|0_0|1|0_0|0.596700013|0_0|1|0
attN = StackNodeTwo,Null_0_0|0.198883504|0_0|-1|0_0|0.198883504|0_0|-1|0
```
The CLS window and highlights also confirm that the vessel has been seperated into two spaces, as the octo core and the lab are no longer considered stack connected. Note that it might need to change the craft a bit (e.g. stack an RCS tank in the bottom like I did in the pic) for CLS to update its previews.

Sorry no log for this as I think it is unnecessary.

# Possible cause

When updating shift nodes, the attatchedPart is assigned null for the previous node:
https://github.com/linuxgurugamer/universal-storage-2/blob/2433a336be72dabbc5870b2aecf915978e002e79/USSourceDev/UniversalStorage/SwitchModules/USNodeSwitch.cs#L143-L145

So when newNode == previousNode, both become null as they are actually the same node.

# Solution

The fix is also simple. Assign the newNode only AFTER the previousNode is cleared.

# Result

The attN value and CLS connection status should now be persistent across saves and updates. I've built the dll and tested on my own instance of KSP.

Again sorry no pics because they are all the same to the first pic.