### PR TITLE
Bring Octo CLS switcher in line with main type switch.

### DIFF
--- a/GameData/UniversalStorage2/Parts/Structural/US_Octo.cfg
+++ b/GameData/UniversalStorage2/Parts/Structural/US_Octo.cfg
@@ -62,7 +62,7 @@ PART
 				SwitchID = 1
 				TargetModule = ModuleConnectedLivingSpace
 				TargetFields = passable
-				TargetValues = true;false;false
+				TargetValues = true;false;false;false
 			}
 
 		// Universal Storage Cost and Mass control for part versions


### PR DESCRIPTION
The Octo core's type switcher has four settings (Crew, LFO, Monoprop, Xenon), but the Connected Living Space USModuleSwitch only had three. While I haven't seen any in-game problems from the missing setting, better safe than sorry.