### PR TITLE
Fix missing DMagic Solar Particle Collector experiment name on advanced sub-satellite

### DIFF
--- a/GameData/UniversalStorage2/Parts/Science/AdvancedMicroSatWedge.cfg
+++ b/GameData/UniversalStorage2/Parts/Science/AdvancedMicroSatWedge.cfg
@@ -322,6 +322,7 @@ PART
 	{
 		name = USSimpleScience
 		experimentID = dmSolarParticles
+		experimentActionName = Collect Solar Particles
 		startEventGUIName = Deploy Solar Particle Collectors 
 		endEventGUIName = Retract Solar Particle Collectors
 		resetActionName = #autoLOC_502049 //#autoLOC_502049 = Discard Data


### PR DESCRIPTION
Fixes missing experimentActionName for solar particle collector showing "#autoLOC_6001437" instead of "Collect Solar Particles"
Before:
![360873601-f7476e3b-1ccf-4cc8-90cd-6e9c350f090f](https://github.com/user-attachments/assets/6e1e497b-467a-4d3f-8946-b8896cdfb838)
After:
![360889291-5d3ec4a0-d81e-45e4-b2b3-a49bb6b04a88](https://github.com/user-attachments/assets/04f28340-f94c-40d9-b2e6-650f9b0fbdbf)
